### PR TITLE
fix: revert trailing slashes

### DIFF
--- a/frontend/website/gatsby-config.ts
+++ b/frontend/website/gatsby-config.ts
@@ -84,7 +84,7 @@ const config: GatsbyConfig = {
     "gatsby-transformer-remark",
     "gatsby-transformer-sharp",
   ],
-  trailingSlash: 'never',
+  trailingSlash: 'always',
 };
 
 export default config;


### PR DESCRIPTION
Because it breaks CloudFront navigation