### PR TITLE
fix: allow requests to Google's Open Source Insights for provenance

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,6 +24,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.deps.dev:443
             api.github.com:443
             api.securityscorecards.dev:443
             github.com:443


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Expanded network access for the Dependency Review process by adding a new endpoint (`api.deps.dev:443`) to the allowed list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->